### PR TITLE
Fix Home Page button font styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -23,6 +23,11 @@ button {
 }
 
 @font-face {
+  font-family: 'PoppinsRegular';
+  src: url('fonts/Poppins-Regular.ttf') format('truetype');
+}
+
+@font-face {
   font-family: 'PoppinsMedium';
   src: url('fonts/Poppins-Medium.ttf') format('truetype');
 }

--- a/src/common/components/GenericButton.jsx
+++ b/src/common/components/GenericButton.jsx
@@ -18,6 +18,7 @@ const StyledButton = styled.button`
   justify-content: center;
   gap: 8px;
   transition: all 0.2s ease-in-out;
+  font-family: 'PoppinsRegular';
 
   &:hover {
     background-color: ${(props) => props.hoverBgColor};


### PR DESCRIPTION
Font of buttons on front page changed to Poppins-Regular to match the Figma. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published
